### PR TITLE
Refactored AuthProvider for cleaner User Auth state management

### DIFF
--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -5,12 +5,12 @@ import NavBar from "./components/NavBar";
 import { MovieProvider } from "./contexts/MovieContext";
 import Register from "./pages/Register";
 import Login from "./pages/Login";
-import { UserProvider } from "./contexts/UserContext";
+import { AuthProvider } from "./contexts/UserContext";
 import "./css/App.css";
 
 function App() {
   return (
-    <UserProvider>
+    <AuthProvider>
         <NavBar />
         <main className="main-content">
           <Routes>
@@ -19,7 +19,7 @@ function App() {
             <Route path="/register" element={<Register />} />
           </Routes>
         </main>
-    </UserProvider>
+    </AuthProvider>
   );
 }
 export default App;

--- a/react-app/src/pages/Home.tsx
+++ b/react-app/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import MovieCard from "../components/MovieCard";
 import { useState, useEffect } from "react";
 import { searchMovies, getPopularMovies } from "../services/api";
-import { useUser } from "../contexts/UserContext";
+import { useAuth } from "../contexts/UserContext";
 import "../css/Home.css";
 
 function Home() {
@@ -58,7 +58,7 @@ function Home() {
   //         Search
   //       </button>
   //     </form>
-      
+
   //       {error && <div className="error-message">{error}</div>}
 
   //     {loading ? (
@@ -73,15 +73,15 @@ function Home() {
   //   </div>
   // );
 
-  const { user, logout } = useUser();  // Get the user and logout function from context
-
+  // const { user, logout } = useUser();  // Get the user and logout function from context
+  const { user, isAuthenticated, login, logout } = useAuth();
   if (!user) {
     return <h2>Please log in to see the homepage.</h2>;
   }
 
   return (
     <div>
-      <h1>Welcome, { user }!</h1>
+      <h1>Welcome, {user.userName}!</h1>
       <button onClick={logout}>Logout</button>
     </div>
   );

--- a/react-app/src/pages/Login.tsx
+++ b/react-app/src/pages/Login.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import { validateEmail } from "../utils/utils";
 import { requestLogin } from "../services/api";
-import { useNavigate } from 'react-router-dom'; 
-import { useUser } from "../contexts/UserContext";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../contexts/UserContext";
 import "../css/Login.css";
 
 export interface LoginFormData {
@@ -11,8 +11,8 @@ export interface LoginFormData {
 }
 
 function Login() {
-
-  const { login } = useUser(); // Get the login function from context
+  // const { login } = useUser(); // Get the login function from context
+  const { user, isAuthenticated, login, logout } = useAuth();
   const navigate = useNavigate();
   const [formData, setFormData] = useState<LoginFormData>({
     email: "",
@@ -34,63 +34,60 @@ function Login() {
     e.preventDefault();
 
     try {
-      // Pass the formData to the requestRegister API function
-      await requestLogin(formData);
-      navigate('/');
+      await login(formData);
+      navigate("/");
       alert("You are now logged in");
-      const userData = formData.email
-      login(userData)
       clearForm();
     } catch (error) {
       console.error(error);
-      alert("Login failed")
+      alert("Login failed");
     } finally {
       clearForm();
     }
   };
 
   return (
-      <div className="login">
-        <form onSubmit={handleSubmit}>
-          <fieldset>
-            <h2>Login</h2>
+    <div className="login">
+      <form onSubmit={handleSubmit}>
+        <fieldset>
+          <h2>Login</h2>
 
-            <div className="Field">
-              <label>
-                Email address <sup>*</sup>
-              </label>
-              <input
-                value={formData.email}
-                onChange={(e) =>
-                  setFormData({ ...formData, email: e.target.value })
-                }
-                placeholder="Email address"
-              />
-            </div>
+          <div className="Field">
+            <label>
+              Email address <sup>*</sup>
+            </label>
+            <input
+              value={formData.email}
+              onChange={(e) =>
+                setFormData({ ...formData, email: e.target.value })
+              }
+              placeholder="Email address"
+            />
+          </div>
 
-            <div className="Field">
-              <label>
-                Password <sup>*</sup>
-              </label>
-              <input
-                value={formData.password}
-                type="password"
-                onChange={(e) => {
-                  setFormData({ ...formData, password: e.target.value });
-                }}
-                onBlur={(e) => {
-                  setFormData({ ...formData, password: e.target.value });
-                }}
-                placeholder="Password"
-              />
-            </div>
+          <div className="Field">
+            <label>
+              Password <sup>*</sup>
+            </label>
+            <input
+              value={formData.password}
+              type="password"
+              onChange={(e) => {
+                setFormData({ ...formData, password: e.target.value });
+              }}
+              onBlur={(e) => {
+                setFormData({ ...formData, password: e.target.value });
+              }}
+              placeholder="Password"
+            />
+          </div>
 
-            <button type="submit" disabled={!getIsFormValid()}>
-              Log In
-            </button>
-          </fieldset>
-        </form>
-      </div>
+          <button type="submit" disabled={!getIsFormValid()}>
+            Log In
+          </button>
+        </fieldset>
+      </form>
+    </div>
   );
 }
 

--- a/react-app/src/services/auth.ts
+++ b/react-app/src/services/auth.ts
@@ -1,0 +1,67 @@
+// src/services/auth.ts
+import { LoginFormData, RegistrationFormData, User } from '../types/auth';
+
+const API_URL = 'http://localhost:5281';
+
+export class AuthService {
+  static async login(data: LoginFormData): Promise<{ user: User; token: string }> {
+    const response = await fetch(`${API_URL}/login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        email: data.email,
+        password: data.password,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Login failed');
+    }
+
+    const responseData = await response.json();
+    return {
+      token: responseData.accessToken,
+      user: await this.getUserProfile(responseData.accessToken),
+    };
+  }
+
+  static async register(data: RegistrationFormData): Promise<void> {
+    const response = await fetch(`${API_URL}/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        email: data.email,
+        password: data.password,
+        firstname: data.firstName,
+        lastname: data.lastName,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error('Registration failed');
+    }
+  }
+
+  static async getUserProfile(token: string): Promise<User> {
+    const response = await fetch(`${API_URL}/api/user`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Authorization': `Bearer ${token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch user profile');
+    }
+
+    return response.json();
+  }
+}

--- a/react-app/src/types/auth.ts
+++ b/react-app/src/types/auth.ts
@@ -1,0 +1,23 @@
+// src/types/auth.ts
+export interface User {
+    userName: string;
+    email?: string;
+  }
+  
+  export interface AuthState {
+    user: User | null;
+    token: string | null;
+    isAuthenticated: boolean;
+  }
+  
+  export interface LoginFormData {
+    email: string;
+    password: string;
+  }
+  
+  export interface RegistrationFormData {
+    email: string;
+    password: string;
+    firstName: string;
+    lastName: string;
+  }


### PR DESCRIPTION
Moved authentication login/logout logic from services/api.ts to its own services/auth.ts file for better separation of responsibilities.  Fully transferred all user state management logic to UserContext, including new isAuthenticated property to be passed to all children for better state management. Now only authToken is stored locally to persist across sessions.